### PR TITLE
link ply into connectal/scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ before_script:
   - ln -s /usr/lib/x86_64-linux-gnu/libgmp.so.10 lib/libgmp.so.3
   # download and install ply
   - curl http://www.dabeaz.com/ply/ply-3.9.tar.gz | tar -zxf -
-  - ln -s ../ply-3.9/ply scripts
+  - ln -s ../ply-3.9/ply connectal/scripts
   - ls -l scripts/ply
 script:
   - ls Bluespec-2016.07.beta1


### PR DESCRIPTION
Currently, ply is linked into a directory that is not in PYTHONPATH. This change links it into connectal/scripts.